### PR TITLE
[AIRFLOW-6175] Prevent dequeue of new queued tasks

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -485,7 +485,7 @@ class BackfillJob(BaseJob):
                         self.log.debug('Sending %s to executor', ti)
                         # Skip scheduled state, we are executing immediately
                         ti.state = State.QUEUED
-                        ti.queued_dttm = timezone.utcnow() if not ti.queued_dttm else ti.queued_dttm
+                        ti.queued_dttm = timezone.utcnow()
                         session.merge(ti)
 
                         cfg_path = None

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -323,6 +323,7 @@ class SchedulerJob(BaseJob):
         'polymorphic_identity': 'SchedulerJob'
     }
     heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
+    job_heartbeat_sec = conf.getint('scheduler', 'JOB_HEARTBEAT_SEC')
 
     def __init__(
             self,
@@ -1054,9 +1055,7 @@ class SchedulerJob(BaseJob):
         # set TIs to queued state
         for task_instance in tis_to_set_to_queued:
             task_instance.state = State.QUEUED
-            task_instance.queued_dttm = (timezone.utcnow()
-                                         if not task_instance.queued_dttm
-                                         else task_instance.queued_dttm)
+            task_instance.queued_dttm = timezone.utcnow()
             session.merge(task_instance)
 
         # Generate a list of SimpleTaskInstance for the use of queuing
@@ -1169,7 +1168,15 @@ class SchedulerJob(BaseJob):
                     # The TI.try_number will return raw try_number+1 since the
                     # ti is not running. And we need to -1 to match the DB record.
                     TI._try_number == try_number - 1,
-                    TI.state == State.QUEUED)
+                    TI.state == State.QUEUED,
+                    # [AIRFLOW-6190] Give the executor time to run very new tasks.
+                    # Sometimes it may be delayed by its own heartbeat loop
+                    # so wait for at least job_heartbeat_sec to elapse
+                    # plus some extra before de-queueing a task
+                    TI.queued_dttm < (
+                        timezone.utcnow() - timedelta(seconds=self.job_heartbeat_sec+5)
+                        )
+                    )
                     for dag_id, task_id, execution_date, try_number
                     in self.executor.queued_tasks.keys()])
             ti_query = (session.query(TI)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
